### PR TITLE
#65 Compare Clan Statistics

### DIFF
--- a/tt2/core/bot.py
+++ b/tt2/core/bot.py
@@ -9,7 +9,7 @@ from settings import (
 )
 
 from tt2.core.maps import *
-from tt2.core.constants import STAGE_PARSE_THRESHOLD, FUNCTION_LOOP_TIMEOUT
+from tt2.core.constants import STAGE_PARSE_THRESHOLD, FUNCTION_LOOP_TIMEOUT, STATS_DATETIME_FMT
 from tt2.core.grabber import Grabber
 from tt2.core.configure import Config
 from tt2.core.stats import Stats
@@ -564,8 +564,7 @@ class Bot:
         Note: This is not an automated process but a good way to currently ensure that parsed values are correct
         for the user.
         """
-        now = datetime.datetime.now()
-        timestamp = str(now)
+        timestamp = datetime.datetime.now().strftime(STATS_DATETIME_FMT)
         self.logger.info("========================================")
         self.logger.info("Beginning Manual Clan Parsing...")
         self.logger.info("Open Your Clan Panel To Begin.")
@@ -576,6 +575,7 @@ class Bot:
         self.logger.info("Clan Panel Is Open... Beginning Clan Statistics Parse")
         self.logger.info("TIMESTAMP: {timestamp}".format(timestamp=timestamp))
         clan_data = self.stats.clan_manual(timestamp=timestamp)
+        cache = self.stats.clan_statistics.setdefault("cache", {})
 
         self.logger.info("========================================")
         self.logger.info("Beginning Individual User Parsing...")
@@ -596,9 +596,9 @@ class Bot:
             # Reaching here ONLY if a profile has been opened.
             self.logger.info("========================================")
             self.logger.info("Parsing Player Profile Now...")
-            player = self.stats.player_manual(clan_key=clan_data["key"], timestamp=timestamp)
+            player, cache = self.stats.player_manual(clan_key=clan_data["code"], timestamp=timestamp, cache=cache)
             self.logger.info("========================================")
-            self.logger.info("PLAYER: {player} WAS PARSED SUCCESSFULLY...".format(player=player["key"]))
+            self.logger.info("PLAYER: {player} WAS PARSED SUCCESSFULLY...".format(player=player["id"]))
             self.logger.info("You may press ctrl+x to finish parsing and save clan statistics OR click on another player to keep parsing.")
 
     @not_in_transition

--- a/tt2/core/constants.py
+++ b/tt2/core/constants.py
@@ -59,6 +59,8 @@ STATS_DURATION_RE = re.compile(
 STATS_TIMEDELTA_STR = "{D}d {H}:{M}:{S}"
 # Stats date format for session keys.
 STATS_DATE_FMT = "%Y-%m-%d"
+# Stats datetime format used for storing keys with a date and times included.
+STATS_DATETIME_FMT = "%Y-%m-%dT%H:%M:%S"
 
 # Stats constants and variables used when parsing clan information to determine and coerce values.
 # {key: INDEX_TO_GRAB, COERCE_TYPE, CHAR_TO_REMOVE}

--- a/tt2/core/run.py
+++ b/tt2/core/run.py
@@ -15,6 +15,8 @@ if __name__ == '__main__':
     parser.add_argument("-start", action="store_true", default=False, help="Initialize a new bot instance and begin automation. (Ensure that the bot screen is open and at the top-left most portion of the screen).")
     parser.add_argument("-parse_artifacts", action="store_true", default=False, help="Parse artifacts in game. May take up to two minutes. Check your stats file afterwards to view the results.")
     parser.add_argument("-parse_clan", action="store_true", default=False, help="Parse clan statistics in game.")
+    parser.add_argument("-compare_clan_stats", nargs=1, help="Compare a clans statistics, the name of the clan should be included here.")
+    parser.add_argument("--keys", nargs="+")
 
     arguments = parser.parse_args()
     if arguments.start:
@@ -26,5 +28,8 @@ if __name__ == '__main__':
     elif arguments.parse_clan:
         from tt2.tools.parse_clan import parse_clan
         parse_clan()
+    elif arguments.compare_clan_stats:
+        from tt2.tools.compare_clan_stats import compare_clan_stats
+        compare_clan_stats(arguments.compare_clan_stats[0], arguments.keys)
     else:
         parser.print_help()

--- a/tt2/core/utilities.py
+++ b/tt2/core/utilities.py
@@ -220,4 +220,7 @@ def make_logger(log_level="INFO", log_format=LOGGER_FORMAT, log_name=LOGGER_NAME
 
 def match(string, search=re.compile(r'[^a-zA-Z0-9]').search):
     """Check a string to determine that it only contains the compiled pattern."""
-    return not bool(search(string))
+    try:
+        return not bool(search(string))
+    except TypeError:
+        return False

--- a/tt2/tools/compare_clan_stats.py
+++ b/tt2/tools/compare_clan_stats.py
@@ -1,0 +1,27 @@
+"""
+parse_clan.py
+
+Make use of this file to manually start a comparison between the specified clan statistic parsed stats.
+"""
+from settings import TOOL_LOG_DIR, CONFIG_FILE
+from tt2.core.bot import Bot
+from tt2.core.utilities import make_logger
+
+import datetime
+
+LOGGER_FILE_NAME_STRFMT = "%Y-%m-%d_%H-%M-%S"
+INIT_DATE_FMT = datetime.datetime.strftime(datetime.datetime.now(), LOGGER_FILE_NAME_STRFMT)
+LOGGER_FILE_NAME = "{log_dir}/{file}-{name}.log".format(
+    file="parse_artifacts", log_dir=TOOL_LOG_DIR, name=INIT_DATE_FMT
+)
+logger = make_logger(log_file=LOGGER_FILE_NAME)
+
+
+def compare_clan_stats(code, keys):
+    """Begin comparison between both keys specified for the given clan."""
+    logger.info("beginning clan statistics comparison process")
+    logger.info("generating a bot instance to perform clan comparisons.")
+
+    bot = Bot(CONFIG_FILE, logger=logger)
+
+    bot.stats.compare_clan_stats(code=code, keys=keys)


### PR DESCRIPTION
- Added new command "compare_clan_stats" that takes in some stat keys.
- TypeError now handled when matching a string to a regular expression through match util.
- Stats keys will now follow the key format: "%Y-%m-%dT%H:%M:%S".
- A cache is now used to improve the parsing ability of manual clan parsing. If an incorrect value is parsed for a key, store the incorrect value and the manually chosen value and the next time this incorrect parse happens, use the fixed version implicitly.
- Keys for clan and players will now just be their ID/CODE. Username is present within player object.